### PR TITLE
Exclude GitHub Actions from PR source check

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-branch:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.actor != 'github-actions'
     runs-on: ubuntu-latest
     steps:
       - name: Validate source branch rules


### PR DESCRIPTION
Updates the workflow to skip branch validation when the actor is 'github-actions', preventing unnecessary checks on automated PRs.