### PR TITLE
Improve PR sync workflow with duplicate PR handling

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -43,20 +43,42 @@ jobs:
         id: source_branch
         run: echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
 
-      - name: Auto-create PRs for downstream branches
+      - name: Sync main to dev/release/hotfix if needed
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           SRC=${{ steps.source_branch.outputs.branch }}
           echo "🔁 PR was merged from: $SRC"
 
-          if [[ "$SRC" == hotfix ]]; then
-            echo "📌 hotfix merged to main, opening PRs to dev & release..."
-            gh pr create --base dev --head main --title "🔄 Sync: main → dev (from $SRC)" --body "Automated PR after hotfix merge to main"
-            gh pr create --base release --head main --title "🔄 Sync: main → release (from $SRC)" --body "Automated PR after hotfix merge to main"
-          elif [[ "$SRC" == release ]]; then
-            echo "📌 release merged to main, opening PRs to dev & hotfix..."
-            gh pr create --base dev --head main --title "🔄 Sync: main → dev (from $SRC)" --body "Automated PR after release merge to main"
-            gh pr create --base hotfix --head main --title "🔄 Sync: main → hotfix (from $SRC)" --body "Automated PR after release merge to main"
+          close_existing_pr() {
+            local BASE=$1
+            local HEAD=main
+            echo "🔍 Checking for existing PR: $HEAD → $BASE"
+            pr_url=$(gh pr list --base "$BASE" --head "$HEAD" --state open --json url -q '.[0].url')
+            if [[ -n "$pr_url" ]]; then
+              echo "⚠️ Existing PR found: $pr_url — closing it..."
+              gh pr close "$pr_url" --comment "🔁 Replaced by a new sync PR from main."
+            fi
+          }
+
+          create_sync_pr() {
+            local BASE=$1
+            echo "📤 Creating PR: main → $BASE"
+            gh pr create --base "$BASE" --head main \
+              --title "🔄 Sync: main → $BASE (from $SRC)" \
+              --body "Automated PR after $SRC merged to main"
+          }
+
+          if [[ "$SRC" == "hotfix" ]]; then
+            echo "📌 hotfix merged to main, syncing to dev & release..."
+            close_existing_pr dev && create_sync_pr dev
+            close_existing_pr release && create_sync_pr release
+
+          elif [[ "$SRC" == "release" ]]; then
+            echo "📌 release merged to main, syncing to dev & hotfix..."
+            close_existing_pr dev && create_sync_pr dev
+            close_existing_pr hotfix && create_sync_pr hotfix
+
           else
-            echo "ℹ️ No matching pattern for source branch. Skipping PR propagation."
+            echo "ℹ️ No downstream sync rules for source branch '$SRC'."
+          fi


### PR DESCRIPTION
Refactors the PR sync step to close any existing open PRs from main to downstream branches before creating new ones. This prevents duplicate PRs and ensures a cleaner workflow when syncing main to dev, release, or hotfix after merges from hotfix or release branches.