### PR TITLE
Update PR source check for GitHub Actions bot

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-branch:
-    if: github.event.action != 'closed' && github.actor != 'github-actions'
+    if: github.event.action != 'closed' && github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate source branch rules


### PR DESCRIPTION
Changed the workflow condition to check for 'github-actions[bot]' as the PR author instead of using 'github.actor'. This ensures the workflow only runs for PRs not created by the GitHub Actions bot.