### PR TITLE
Restrict PRs to release branch from dev only

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -17,7 +17,7 @@ jobs:
           BASE="${{ github.base_ref }}"
           HEAD="${{ github.head_ref }}"
 
-          if [[ "$BASE" == "release" && "$HEAD" != "dev" ]]; then
+          if [[ "$BASE" == "release" && "$HEAD" != "dev" && "$GITHUB_ACTOR" != "github-actions[bot]"]]; then
             echo "::error::❌ Only 'dev' is allowed to open PRs to 'release'"
             exit 1
           fi


### PR DESCRIPTION
Updated the workflow to prevent users other than 'github-actions[bot]' from opening pull requests to the 'release' branch unless the source branch is 'dev'.