### PR TITLE
Allow all users to open PRs from 'dev' to 'release'

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -17,7 +17,7 @@ jobs:
           BASE="${{ github.base_ref }}"
           HEAD="${{ github.head_ref }}"
 
-          if [[ "$BASE" == "release" && "$HEAD" != "dev" && "$GITHUB_ACTOR" != "github-actions[bot]" ]]; then
+          if [[ "$BASE" == "release" && "$HEAD" != "dev" ]]; then
             echo "::error::❌ Only 'dev' is allowed to open PRs to 'release'"
             exit 1
           fi


### PR DESCRIPTION
Removed the restriction that blocked PRs to 'release' from users other than 'github-actions[bot]'. Now, any PR from 'dev' to 'release' is allowed regardless of the actor.