### PR TITLE
Skip PR source validation for GitHub Actions bots

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -17,7 +17,12 @@ jobs:
           BASE="${{ github.base_ref }}"
           HEAD="${{ github.head_ref }}"
 
-          if [[ "$BASE" == "release" && "$HEAD" != "dev" && "$GITHUB_ACTOR" != "github-actions[bot]" ]]; then
+          if [[ "$ACTOR" == "github-actions" || "$ACTOR" == "github-actions[bot]" ]]; then
+            echo "🤖 Bot PR detected, skipping validation."
+            exit 0
+          fi
+
+          if [[ "$BASE" == "release" && "$HEAD" != "dev" ]]; then
             echo "::error::❌ Only 'dev' is allowed to open PRs to 'release'"
             exit 1
           fi


### PR DESCRIPTION
Updates the workflow to bypass PR source validation when the PR is created by GitHub Actions bots, preventing unnecessary validation errors for automated PRs.