### PR TITLE
Fix missing 'fi' in check-pr-source workflow

### DIFF
--- a/.github/workflows/check-pr-source.yml
+++ b/.github/workflows/check-pr-source.yml
@@ -97,3 +97,4 @@ jobs:
 
           else
             echo "ℹ️ No downstream sync rules for source branch '$SRC'."
+          fi


### PR DESCRIPTION
Adds a missing 'fi' to properly close the conditional statement in the GitHub Actions workflow, ensuring correct script execution.